### PR TITLE
Mango Notifi Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@blockworks-foundation/mango-client": "^3.2.9",
     "@koa/cors": "^3.1.0",
-    "@notifi-network/notifi-node": "^0.6.0",
+    "@notifi-network/notifi-node": "^0.7.0",
     "@solana/web3.js": "^1.2.6",
     "dotenv": "^8.2.0",
     "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@blockworks-foundation/mango-client": "^3.2.9",
     "@koa/cors": "^3.1.0",
+    "@notifi-network/notifi-node": "^0.6.0",
     "@solana/web3.js": "^1.2.6",
     "dotenv": "^8.2.0",
     "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@blockworks-foundation/mango-client": "^3.2.9",
     "@koa/cors": "^3.1.0",
-    "@notifi-network/notifi-node": "^0.7.0",
+    "@notifi-network/notifi-node": "^0.8.0",
     "@solana/web3.js": "^1.2.6",
     "dotenv": "^8.2.0",
     "email-validator": "^2.0.4",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -14,4 +14,6 @@ export default {
   mailJetKey: process.env.MAILJET_KEY || "",
   mailJetSecret: process.env.MAILJET_SECRET || "",
   updatePassword: process.env.UPDATE_PASSWORD,
+  notifiSid: process.env.NOTIFI_SID || "",
+  notifiSecret: process.env.NOTIFI_SECRET || ""
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,7 @@ const handleAlert = async (alert: any, db: any) => {
       mangoAccountPk,
       mangoGroup.dexProgramId
     )
+    const walletPublicKey = mangoAccount.owner.toBase58();
     const health = await mangoAccount.getHealthRatio(
       mangoGroup,
       mangoCache,
@@ -263,8 +264,7 @@ const handleAlert = async (alert: any, db: any) => {
       message +=
         "Deposit more collateral or reduce your liabilities to improve your account health. \n"
       message += `View your account: https://trade.mango.markets/account?pubkey=${alert.mangoAccountPk}`
-      // TODO: Replace with notifi SDK
-      const alertSent = await sendAlert(alert, message)
+      const alertSent = await sendAlert(alert, message, Number(health), walletPublicKey)
       if (alertSent) {
         db.collection("alerts").deleteOne({ _id: alert._id })
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,6 @@ app.use(
 router.post("/alerts", async (ctx, next) => {
   try {
     const alert: any = ctx.request.body
-    await validateMangoAccount(client, alert)
-    validateEmail(alert.email)
     ctx.body = { status: "success" }
     alert.open = true
     alert.timestamp = Date.now()
@@ -115,6 +113,7 @@ router.get("/alerts/:mangoAccountPk", async (ctx, next) => {
             open: 1,
             timestamp: 1,
             triggeredTimestamp: 1,
+            notifiAlertId: 1,
           },
         }
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   validateEmail,
   sendAlert,
   validateUpdatePassword,
+  validateNotifiAlertId,
 } from "./utils"
 import config from "./environment"
 
@@ -63,7 +64,13 @@ router.post("/alerts", async (ctx, next) => {
   try {
     const alert: any = ctx.request.body
     await validateMangoAccount(client, alert)
-    validateEmail(alert.email)
+    if (alert.alertProvider === 'mail') {
+      validateEmail(alert.email)
+    } else if (alert.alertProvider === 'notifi') {
+      validateNotifiAlertId(alert.notifiAlertId)
+    } else {
+      throw new UserError("Invalid alertProvider")
+    }
     ctx.body = { status: "success" }
     alert.open = true
     alert.timestamp = Date.now()
@@ -256,6 +263,7 @@ const handleAlert = async (alert: any, db: any) => {
       message +=
         "Deposit more collateral or reduce your liabilities to improve your account health. \n"
       message += `View your account: https://trade.mango.markets/account?pubkey=${alert.mangoAccountPk}`
+      // TODO: Replace with notifi SDK
       const alertSent = await sendAlert(alert, message)
       if (alertSent) {
         db.collection("alerts").deleteOne({ _id: alert._id })

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ app.use(
 router.post("/alerts", async (ctx, next) => {
   try {
     const alert: any = ctx.request.body
+    await validateMangoAccount(client, alert)
+    validateEmail(alert.email)
     ctx.body = { status: "success" }
     alert.open = true
     alert.timestamp = Date.now()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,13 @@ export const validateEmail = (email: string) => {
   return
 }
 
+export const validateNotifiAlertId = (notifiAlertId: string) => {
+  if (!notifiAlertId) {
+    throw new UserError("Invalid notifiAlertId")
+  }
+  return
+}
+
 const sendEmail = async (email: string, message: string) => {
   const transport = nodemailer.createTransport(
     mailjetTransport({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,7 @@ const sendNotifiAlert = async (alertId: string, health: number, walletPublicKey:
         healthValue: health,
       })
       console.log(`sending alert with key: ${key}, walletPublicKey: ${walletPublicKey}, value: ${health}`);
+      return true
     } else {
       throw new UserError("Invalid jwt, please login")
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,12 +115,9 @@ const sendNotifiAlert = async (alertId: string, health: number, walletPublicKey:
         key,
         walletPublicKey,
         walletBlockchain: "SOLANA",
-        value: health,
+        healthValue: health,
       })
       console.log(`sending alert with key: ${key}, walletPublicKey: ${walletPublicKey}, value: ${health}`);
-      // call notifi to delete user alert
-      await notifiClient.deleteUserAlert(jwt, { alertId })
-      console.log(`deleted alertId: ${alertId}`);
     } else {
       throw new UserError("Invalid jwt, please login")
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,7 +107,7 @@ const sendNotifiAlert = async (alertId: string, health: number, walletPublicKey:
   try {
     // login with sid/secret to get jwt
     const { token: jwt, expiry } = await notifiClient.logIn({ sid, secret })
-    console.log(`login successfully, received jwt expire at ${expiry}`)
+    // console.log(`login successfully, received jwt expire at ${expiry}`)
     if (jwt) {
       // trigger notifi to send notification
       const key = randomUUID()
@@ -117,7 +117,7 @@ const sendNotifiAlert = async (alertId: string, health: number, walletPublicKey:
         walletBlockchain: "SOLANA",
         healthValue: health,
       })
-      console.log(`sending alert with key: ${key}, walletPublicKey: ${walletPublicKey}, value: ${health}`);
+      // console.log(`sending alert with key: ${key}, walletPublicKey: ${walletPublicKey}, value: ${health}`);
       return true
     } else {
       throw new UserError("Invalid jwt, please login")

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,17 +65,17 @@
   dependencies:
     vary "^1.1.2"
 
-"@notifi-network/notifi-axios-utils@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.6.0.tgz#1c0f358c6537547d3f2cc023d30ce858fea0fb49"
-  integrity sha512-LXtQYpAlrUHp/beIpVwxgutjINxDszvmaH7OLOJktUQ2uRXog14qJI3hsFRGa7rdCHRkEcE+l5eU92jrUEaW5A==
+"@notifi-network/notifi-axios-utils@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.7.0.tgz#0caf00f88cf0f08e004de2e228b870ff2592e9a7"
+  integrity sha512-guBCh1Jo3iH7BkcvkTH+vPVdMNlcWomVMsfoNWlcH3FbUrj5xIdZq6r+ADafgjquQ8NbajRqPGCYErU7FS6Szw==
 
-"@notifi-network/notifi-node@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-node/-/notifi-node-0.6.0.tgz#4063263298e6711742f4fcaadeef3c107a86fbe0"
-  integrity sha512-wHYb+xwiJXMk+rdtBlVObOoHmD/4y9qKuNJdGnKgAgrJQmSLZxCxsnG/+5+xhDIygPyPssMTRbrrjzWa/Nl1xw==
+"@notifi-network/notifi-node@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-node/-/notifi-node-0.7.0.tgz#12f53cfe323ea9f05d3f9caaa6d7db4f081b472b"
+  integrity sha512-sf3wFdbCIVKj6oGRcQEKnZWjovnXHUFzup8ILPWZFK3nIaK885c3l5rKdS+WW1pwSVWT47HQZtbxvxPy3b/3fw==
   dependencies:
-    "@notifi-network/notifi-axios-utils" "^0.6.0"
+    "@notifi-network/notifi-axios-utils" "^0.7.0"
 
 "@project-serum/anchor@^0.11.1":
   version "0.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,17 +65,17 @@
   dependencies:
     vary "^1.1.2"
 
-"@notifi-network/notifi-axios-utils@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.7.0.tgz#0caf00f88cf0f08e004de2e228b870ff2592e9a7"
-  integrity sha512-guBCh1Jo3iH7BkcvkTH+vPVdMNlcWomVMsfoNWlcH3FbUrj5xIdZq6r+ADafgjquQ8NbajRqPGCYErU7FS6Szw==
+"@notifi-network/notifi-axios-utils@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.8.0.tgz#83ac4a649ee9facbd32a8d121748bb5c827f9c4f"
+  integrity sha512-q+RDUZ2gRkLl0gfKy6pVQrZHe9fGwLa+zH1Fy+dm3U6SCyAZX8cjqiLpFLYVJE89nguMMc28tnp3T5K39+wBlQ==
 
-"@notifi-network/notifi-node@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-node/-/notifi-node-0.7.0.tgz#12f53cfe323ea9f05d3f9caaa6d7db4f081b472b"
-  integrity sha512-sf3wFdbCIVKj6oGRcQEKnZWjovnXHUFzup8ILPWZFK3nIaK885c3l5rKdS+WW1pwSVWT47HQZtbxvxPy3b/3fw==
+"@notifi-network/notifi-node@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-node/-/notifi-node-0.8.0.tgz#0c91b5f3ac27c41e4b54ddd5eed8a9118e54a2e6"
+  integrity sha512-bgleeL1M6RMm0GQFKhXETH6fbtDOJ7poqBX/VPg2ZTG7hThhYcxlFnYhQ33/qnG2FsMmYq1YjOlCV5Ens6o1XA==
   dependencies:
-    "@notifi-network/notifi-axios-utils" "^0.7.0"
+    "@notifi-network/notifi-axios-utils" "^0.8.0"
 
 "@project-serum/anchor@^0.11.1":
   version "0.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,18 @@
   dependencies:
     vary "^1.1.2"
 
+"@notifi-network/notifi-axios-utils@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.6.0.tgz#1c0f358c6537547d3f2cc023d30ce858fea0fb49"
+  integrity sha512-LXtQYpAlrUHp/beIpVwxgutjINxDszvmaH7OLOJktUQ2uRXog14qJI3hsFRGa7rdCHRkEcE+l5eU92jrUEaW5A==
+
+"@notifi-network/notifi-node@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-node/-/notifi-node-0.6.0.tgz#4063263298e6711742f4fcaadeef3c107a86fbe0"
+  integrity sha512-wHYb+xwiJXMk+rdtBlVObOoHmD/4y9qKuNJdGnKgAgrJQmSLZxCxsnG/+5+xhDIygPyPssMTRbrrjzWa/Nl1xw==
+  dependencies:
+    "@notifi-network/notifi-axios-utils" "^0.6.0"
+
 "@project-serum/anchor@^0.11.1":
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.11.1.tgz#155bff2c70652eafdcfd5559c81a83bb19cec9ff"


### PR DESCRIPTION
### Notifi Integration
This PR integrates Mango Alert Service with Notifi SDK.

A few things we did in this PR includes:
- Supported new `alert.alertProvider` as `notifi`. For legacy use case when alertProvider = `email`, it keeps as is. For new use case when alertProvider = `notifi`, it will call Notifi SDK to send out alerts.
- Accepted `notifiAlertId` in alert creation object and store it in DB with each alert.
- Created new util methods to handle sending Notifi alerts.

### Testing
To test this locally, you will need to set it up with following steps:
1. Make sure `dbConnectionString, db, port` in `environment.ts` point to your local accessible mongo db instance.
2. Notifi SDK requires a `SID/SECRET` pair in order to login and retain a valid JWT. Ask Notifi team on [discord](https://discord.gg/qCnur3kw) to get a valid pair and make sure to assign it to the env var: `process.env.NOTIFI_SID` and `process.env.NOTIFI_SECRET`.
3. In order to trigger the alert, you can skip the health check by making it always returning `true` and also update the scheduled cron task to run every 5 seconds by replacing the first string with `"*/5 * * * * *"` when calling `cron.schedule` method in `indext.ts`
